### PR TITLE
Add dnsx bulk resolution tool and validation task

### DIFF
--- a/recon/agents.py
+++ b/recon/agents.py
@@ -8,6 +8,7 @@ from langchain_openai import ChatOpenAI
 
 from recon.tools.amass_tool import amass_passive_enum
 from recon.tools.count_tool import count_unique_subdomains
+from recon.tools.dnsx_tool import dnsx_bulk_resolve
 
 llm = ChatOpenAI(model=os.getenv("MODEL_NAME", "gpt-4o-mini"))
 
@@ -19,8 +20,11 @@ passive_recon_agent = Agent(
         "bug-bounty scope. Prioritizes privacy, legality, and reproducibility; "
         "never performs active probing."
     ),
-    tools=[amass_passive_enum,
-           count_unique_subdomains],
+    tools=[
+        amass_passive_enum,
+        count_unique_subdomains,
+        dnsx_bulk_resolve,
+    ],
     allow_delegation=False,
     verbose=True,
     llm=llm,

--- a/recon/crew.py
+++ b/recon/crew.py
@@ -7,7 +7,11 @@ from typing import Dict, Optional
 from crewai import Crew, Process
 
 from recon.agents import passive_recon_agent
-from recon.tasks import summarize_subdomains_task, passive_enum_task
+from recon.tasks import (
+    summarize_subdomains_task,
+    passive_enum_task,
+    validate_subdomains_task,
+)
 from recon.utils import prompt_for_domain
 
 
@@ -18,8 +22,11 @@ def run(target_domain: Optional[str]) -> Dict[str, object]:
 
     crew = Crew(
         agents=[passive_recon_agent],
-        tasks=[passive_enum_task, 
-               summarize_subdomains_task],
+        tasks=[
+            passive_enum_task,
+            validate_subdomains_task,
+            summarize_subdomains_task,
+        ],
         process=Process.sequential,
     )
 

--- a/recon/tasks.py
+++ b/recon/tasks.py
@@ -10,41 +10,39 @@ domain_intake_task = Task(
         "If {target_domain} is missing, obtain it from the user interactively via CLI "
         "before proceeding. Validate it strictly as an FQDN."
     ),
-    expected_output="A validated domain string assigned to target_domain input.",
+    expected_output="A validated target_domain string assigned to target_domain input.",
     agent=passive_recon_agent,
 )
 
 passive_enum_task = Task(
     description=(
         "For {target_domain}, perform passive subdomain enumeration using the provided "
-        "Amass tool. Do not use any active techniques. Provide a concise textual "
-        "summary and the final list of subdomains."
+        "Amass tool. Do not use any active techniques. Provide a list of enumerated_subdomains."
     ),
     expected_output=(
-        "A dictionary with keys: target_domain (str), count (int), and subdomains (list[str])."
+        "A dictionary with keys: target_domain (str), count (int), and enumerated_subdomains (list[str])."
     ),
     agent=passive_recon_agent,
 )
 
 validate_subdomains_task = Task(
     description=(
-        "Validate candidate subdomains from {candidate_subdomains} using the "
-        "dnsx_bulk_resolve tool. Return JSON with keys 'resolvable' and 'results' "
+        "Validate the list of previous enumerated_subdomains using"
+        "dnsx_bulk_resolve tool. Return JSON with keys 'validated_subdomains' and 'results' "
         "listing resolved hosts and their IP addresses."
     ),
     expected_output=(
-        "A JSON object with keys: resolvable (list[str]) and results (list[dict{host: str, ips: list[str]}])."
+        "A JSON object with keys: validated_subdomains (list[str]) and results (list[dict{host: str, ips: list[str]}])."
     ),
     agent=passive_recon_agent,
 )
 
-# Summarize task: count unique subdomains enumerated for the target domain
 summarize_subdomains_task = Task(
     description=(
-        "For {target_domain}, use the count_unique_subdomains tool to count how many unique subdomains were enumerated. "
+        "For {target_domain}, use the count_unique_subdomains tool to count how many unique validated_subdomains were found. "
         "Return only the count and a brief summary."
     ),
-    expected_output="An integer count of unique subdomains and a one-sentence summary.",
+    expected_output="An integer count of unique validated_subdomains and a one-sentence summary.",
     agent=passive_recon_agent,
 )
 

--- a/recon/tasks.py
+++ b/recon/tasks.py
@@ -26,6 +26,18 @@ passive_enum_task = Task(
     agent=passive_recon_agent,
 )
 
+validate_subdomains_task = Task(
+    description=(
+        "Validate candidate subdomains from {candidate_subdomains} using the "
+        "dnsx_bulk_resolve tool. Return JSON with keys 'resolvable' and 'results' "
+        "listing resolved hosts and their IP addresses."
+    ),
+    expected_output=(
+        "A JSON object with keys: resolvable (list[str]) and results (list[dict{host: str, ips: list[str]}])."
+    ),
+    agent=passive_recon_agent,
+)
+
 # Summarize task: count unique subdomains enumerated for the target domain
 summarize_subdomains_task = Task(
     description=(
@@ -38,3 +50,4 @@ summarize_subdomains_task = Task(
 
 __all__ = ["domain_intake_task", "passive_enum_task"]
 __all__.append("summarize_subdomains_task")
+__all__.append("validate_subdomains_task")

--- a/recon/tools/__init__.py
+++ b/recon/tools/__init__.py
@@ -1,3 +1,7 @@
 """Tool package for recon."""
 
-__all__ = ["amass_tool"]
+__all__ = [
+    "amass_tool",
+    "dnsx_tool",
+    "count_tool",
+]

--- a/recon/tools/dnsx_tool.py
+++ b/recon/tools/dnsx_tool.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Dict, List, Sequence
+
+from crewai.tools import tool
+
+
+@tool("dnsx_bulk_resolve")
+def dnsx_bulk_resolve(
+    subdomains: str | Sequence[str],
+    threads: int = 100,
+    resolvers: Sequence[str] | None = None,
+    timeout: int = 5000,
+    retries: int = 2,
+    include_ipv6: bool = False,
+) -> Dict[str, object]:
+    """Resolve many subdomains quickly using ProjectDiscovery's dnsx.
+
+    Parameters
+    ----------
+    subdomains: str | Sequence[str]
+        Candidate subdomains as newline-separated string or iterable of strings.
+    threads: int, optional
+        Number of concurrent threads for dnsx. Defaults to 100.
+    resolvers: Sequence[str] | None, optional
+        Custom DNS resolvers to use. If provided, joined by comma and passed to
+        dnsx via ``-r`` option.
+    timeout: int, optional
+        Timeout in milliseconds for each DNS query. Defaults to 5000.
+    retries: int, optional
+        Number of retry attempts dnsx should make. Defaults to 2.
+    include_ipv6: bool, optional
+        When True, also query AAAA (IPv6) records.
+
+    Returns
+    -------
+    Dict[str, object]
+        Dictionary with keys ``resolvable`` (sorted list of hosts that resolved)
+        and ``results`` (list of objects with ``host`` and ``ips``).
+    """
+    if shutil.which("dnsx") is None:
+        raise FileNotFoundError(
+            "dnsx CLI not found. Install from https://github.com/projectdiscovery/dnsx"
+        )
+
+    # Normalize input into ordered, deduplicated list
+    if isinstance(subdomains, str):
+        raw_items = [line.strip() for line in subdomains.splitlines()]
+    else:
+        raw_items = [str(item).strip() for item in subdomains]
+    seen: set[str] = set()
+    items: List[str] = []
+    for item in raw_items:
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        items.append(item)
+
+    if not items:
+        return {"resolvable": [], "results": []}
+
+    tmp_file = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+    try:
+        tmp_file.write("\n".join(items))
+        tmp_file.flush()
+        tmp_file.close()
+
+        base_cmd = [
+            "dnsx",
+            "-silent",
+            "-json",
+            "-resp",
+            "-l",
+            tmp_file.name,
+            "-t",
+            str(threads),
+            "-retry",
+            str(retries),
+            "-timeout",
+            str(timeout),
+        ]
+        if resolvers:
+            base_cmd.extend(["-r", ",".join(resolvers)])
+
+        query_flags = ["-a"]
+        if include_ipv6:
+            query_flags.append("-aaaa")
+
+        results_by_host: Dict[str, set[str]] = {}
+        for q in query_flags:
+            cmd = base_cmd + [q]
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+            if proc.returncode != 0:
+                stderr = proc.stderr.strip().splitlines()
+                raise RuntimeError(stderr[-1] if stderr else "dnsx execution failed")
+            for line in proc.stdout.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                host = data.get("host") or data.get("name") or data.get("domain")
+                if not host:
+                    continue
+                ips: List[str] = []
+                for key in ("a", "aaaa", "resp"):
+                    value = data.get(key)
+                    if isinstance(value, list):
+                        ips.extend(str(v) for v in value)
+                    elif isinstance(value, str):
+                        ips.append(value)
+                cleaned = [ip for ip in {ip.strip() for ip in ips} if ip]
+                if not cleaned:
+                    continue
+                results_by_host.setdefault(host, set()).update(cleaned)
+
+        resolvable = sorted(results_by_host)
+        results = [
+            {"host": host, "ips": sorted(list(ips))}
+            for host, ips in sorted(results_by_host.items())
+        ]
+        return {"resolvable": resolvable, "results": results}
+    finally:
+        try:
+            os.unlink(tmp_file.name)
+        except OSError:
+            pass

--- a/recon/tools/dnsx_tool.py
+++ b/recon/tools/dnsx_tool.py
@@ -1,134 +1,86 @@
+
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
 import tempfile
-from typing import Dict, List, Sequence
-
+import os
+from typing import List, Dict
+from pprint import pprint
 from crewai.tools import tool
-
+import random
+import string
 
 @tool("dnsx_bulk_resolve")
-def dnsx_bulk_resolve(
-    subdomains: str | Sequence[str],
-    threads: int = 100,
-    resolvers: Sequence[str] | None = None,
-    timeout: int = 5000,
-    retries: int = 2,
-    include_ipv6: bool = False,
-) -> Dict[str, object]:
-    """Resolve many subdomains quickly using ProjectDiscovery's dnsx.
+def dnsx_bulk_resolve(subdomains: list[str]) -> dict[str, object]:
+    """Resolve enumerated subdomains using dnsx and return validated ones with their IPs."""
 
-    Parameters
-    ----------
-    subdomains: str | Sequence[str]
-        Candidate subdomains as newline-separated string or iterable of strings.
-    threads: int, optional
-        Number of concurrent threads for dnsx. Defaults to 100.
-    resolvers: Sequence[str] | None, optional
-        Custom DNS resolvers to use. If provided, joined by comma and passed to
-        dnsx via ``-r`` option.
-    timeout: int, optional
-        Timeout in milliseconds for each DNS query. Defaults to 5000.
-    retries: int, optional
-        Number of retry attempts dnsx should make. Defaults to 2.
-    include_ipv6: bool, optional
-        When True, also query AAAA (IPv6) records.
+    print("Inside Tool dnsBulk")
+    print(len(subdomains))
+    pprint(subdomains)
 
-    Returns
-    -------
-    Dict[str, object]
-        Dictionary with keys ``resolvable`` (sorted list of hosts that resolved)
-        and ``results`` (list of objects with ``host`` and ``ips``).
-    """
     if shutil.which("dnsx") is None:
         raise FileNotFoundError(
             "dnsx CLI not found. Install from https://github.com/projectdiscovery/dnsx"
         )
 
-    # Normalize input into ordered, deduplicated list
-    if isinstance(subdomains, str):
-        raw_items = [line.strip() for line in subdomains.splitlines()]
-    else:
-        raw_items = [str(item).strip() for item in subdomains]
-    seen: set[str] = set()
-    items: List[str] = []
-    for item in raw_items:
-        if not item or item in seen:
-            continue
-        seen.add(item)
-        items.append(item)
-
+    # Deduplicate and clean input
+    items = sorted({s.strip() for s in subdomains if s.strip()})
     if not items:
         return {"resolvable": [], "results": []}
+    
+    # Generate a small random filename for debugging
+    rand_suffix = ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
+    tmp_file_name = f"/tmp/dnsx_input_{rand_suffix}.txt"
 
-    tmp_file = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
-    try:
+    with open(tmp_file_name, "w", encoding="utf-8") as tmp_file:
         tmp_file.write("\n".join(items))
         tmp_file.flush()
-        tmp_file.close()
 
-        base_cmd = [
-            "dnsx",
-            "-silent",
-            "-json",
-            "-resp",
-            "-l",
-            tmp_file.name,
-            "-t",
-            str(threads),
-            "-retry",
-            str(retries),
-            "-timeout",
-            str(timeout),
-        ]
-        if resolvers:
-            base_cmd.extend(["-r", ",".join(resolvers)])
+    cmd = [
+        "dnsx",
+        "-silent",
+        "-json",
+        "-resp",
+        "-l", tmp_file_name,
+        "-t", "100",
+    ]
 
-        query_flags = ["-a"]
-        if include_ipv6:
-            query_flags.append("-aaaa")
+    print(f"[DEBUG] Running command: {' '.join(cmd)}")
+    print(f"[DEBUG] Input file retained at: {tmp_file_name}")
 
-        results_by_host: Dict[str, set[str]] = {}
-        for q in query_flags:
-            cmd = base_cmd + [q]
-            proc = subprocess.run(cmd, capture_output=True, text=True)
-            if proc.returncode != 0:
-                stderr = proc.stderr.strip().splitlines()
-                raise RuntimeError(stderr[-1] if stderr else "dnsx execution failed")
-            for line in proc.stdout.splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    data = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                host = data.get("host") or data.get("name") or data.get("domain")
-                if not host:
-                    continue
-                ips: List[str] = []
-                for key in ("a", "aaaa", "resp"):
-                    value = data.get(key)
-                    if isinstance(value, list):
-                        ips.extend(str(v) for v in value)
-                    elif isinstance(value, str):
-                        ips.append(value)
-                cleaned = [ip for ip in {ip.strip() for ip in ips} if ip]
-                if not cleaned:
-                    continue
-                results_by_host.setdefault(host, set()).update(cleaned)
+    results_by_host: Dict[str, set[str]] = {}
+    proc = subprocess.run(cmd, capture_output=True, text=True)
 
-        resolvable = sorted(results_by_host)
-        results = [
-            {"host": host, "ips": sorted(list(ips))}
-            for host, ips in sorted(results_by_host.items())
-        ]
-        return {"resolvable": resolvable, "results": results}
-    finally:
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip().splitlines()
+        raise RuntimeError(stderr[-1] if stderr else "dnsx execution failed")
+    
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
         try:
-            os.unlink(tmp_file.name)
-        except OSError:
-            pass
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        host = data.get("host") or data.get("name") or data.get("domain")
+        if not host:
+            continue
+        ips = data.get("a", [])
+        if isinstance(ips, str):
+            ips = [ips]
+        elif not isinstance(ips, list):
+            ips = []
+        cleaned = [ip.strip() for ip in ips if ip.strip()]
+        if not cleaned:
+            continue
+        results_by_host.setdefault(host, set()).update(cleaned)
+
+    resolvable = sorted(results_by_host)
+    results = [
+        {"host": host, "ips": sorted(list(ips))}
+        for host, ips in sorted(results_by_host.items())
+    ]
+    return {"resolvable": resolvable, "results": results}


### PR DESCRIPTION
## Summary
- add dnsx bulk DNS resolution tool with temp file handling and JSON output
- expose tool to passive recon agent and crew
- add task to validate candidate subdomains via dnsx

## Testing
- `python -m py_compile recon/tools/dnsx_tool.py recon/agents.py recon/tasks.py recon/crew.py`
- `python -m pytest`
- `python - <<'PY'
from recon.tools.dnsx_tool import dnsx_bulk_resolve
try:
    print(dnsx_bulk_resolve.run(['example.com']))
except Exception as e:
    print('ERROR:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68acba68a34c832ea297cc8e0a918954